### PR TITLE
Support for GHC 9.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        ghc: ['9.6.7', '9.8.4']
+        ghc: ['9.6.7', '9.8.4', '9.12.2']
         os: [ubuntu-latest, macos-latest]
     name: GHC ${{ matrix.ghc }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.6.7', '9.8.4', '9.12.2']
+        ghc: ['9.6.7', '9.8.4', '9.12.2', '9.14.1']
         os: [ubuntu-latest, macos-latest]
     name: GHC ${{ matrix.ghc }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /dist-newstyle/
+.stack-work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 
+* Support for GHC 9.12
 * Support for GHC 9.8.1
 
 1.2.0.0 (December 12, 2021)

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -49,9 +49,6 @@ module Retrie.ExactPrint
 
 import Control.Exception
 import Control.Monad
-#if __GLASGOW_HASKELL__ < 908
-import Data.Default (Default)
-#endif
 import Control.Monad.State.Lazy
 import Data.List (transpose)
 import Text.Printf

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -33,8 +33,6 @@ module Retrie.ExactPrint
   , swapEntryDPT
   , transferAnnsT
   , transferEntryAnnsT
-  -- , tryTransferEntryDPT
-  , transferEpAnn
     -- * Utils
   , debugDump
   , debugParse
@@ -385,17 +383,6 @@ addAllAnnsT a b = do
 addAllAnnsT a b = return $ transferEntryDP a b
 #endif
 
-
--- TODO (xich): remove this and replace usage with addAllAnnsT that does the
--- right thing
-#if __GLASGOW_HASKELL__ < 912
-transferEpAnn :: Default an => LocatedAn an a -> LocatedAn an b -> LocatedAn an b
-transferEpAnn (L (SrcSpanAnn EpAnnNotUsed l)    _) lb = setAnchorAn lb (spanAsAnchor l) emptyComments
-transferEpAnn (L (SrcSpanAnn (EpAnn anc _ _) _) _) lb = setAnchorAn lb anc              emptyComments
-#else
-transferEpAnn :: GenLocated (EpAnn ann) a -> GenLocated (EpAnn ann) b -> GenLocated (EpAnn ann) b
-transferEpAnn (L epann _) (L _ b) = L epann b
-#endif
 
 
 isComma :: TrailingAnn -> Bool

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -49,7 +49,7 @@ module Retrie.ExactPrint
 
 import Control.Exception
 import Control.Monad
-#if __GLASGOW_HASKELL__ < 912
+#if __GLASGOW_HASKELL__ < 908
 import Data.Default (Default)
 #endif
 import Control.Monad.State.Lazy

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+#else
 {-# OPTIONS_GHC -Wno-orphans #-}
 #endif
 -- | Provides consistent interface with ghc-exactprint.
@@ -84,7 +85,8 @@ import Retrie.SYB hiding (ext1)
 
 import GHC.Stack
 
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+#else
 import Data.Default
 import Control.Applicative
 
@@ -197,7 +199,10 @@ fixOneEntry e x = do
       -- lift $ liftIO $ debugPrint Loud "fixOneEntry:(dpx,dpe)="  [showAst ((deltaPos er (xc + ec)),(deltaPos xr 0))]
       -- lift $ liftIO $ debugPrint Loud "fixOneEntry:e'="  [showAst e]
       -- lift $ liftIO $ debugPrint Loud "fixOneEntry:e'="  [showAst (setEntryDP e (deltaPos er (xc + ec)))]
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+      return ( setEntryDP e (deltaPos er (xc + ec))
+             , setEntryDP x (deltaPos xr 0))
+#else
       -- In GHC 9.12+, setEntryDP applies the delta to the first comment if present,
       -- which can corrupt spacing. Skip adjustment when either e or x has comments
       -- directly attached to them (not in subtree), as setEntryDP will be called
@@ -206,9 +211,6 @@ fixOneEntry e x = do
         then return (e, x)
         else return ( setEntryDP e (deltaPos er (xc + ec))
                     , setEntryDP x (deltaPos xr 0))
-#else
-      return ( setEntryDP e (deltaPos er (xc + ec))
-             , setEntryDP x (deltaPos xr 0))
 #endif
     _ -> return (e,x)
 

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -171,10 +171,10 @@ stripComments (SrcSpanAnn EpAnnNotUsed l) = SrcSpanAnn EpAnnNotUsed l
 stripComments (SrcSpanAnn (EpAnn anc an _) l) = SrcSpanAnn (EpAnn anc an emptyComments) l
 #else
 stripComments :: EpAnn an -> EpAnn an
-#if __GLASGOW_HASKELL__ >= 914
-stripComments e = e { comments = emptyComments }
-#else
+#if __GLASGOW_HASKELL__ < 914
 stripComments = removeCommentsA
+#else
+stripComments e = e { comments = emptyComments }
 #endif
 #endif
 

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -171,7 +171,11 @@ stripComments (SrcSpanAnn EpAnnNotUsed l) = SrcSpanAnn EpAnnNotUsed l
 stripComments (SrcSpanAnn (EpAnn anc an _) l) = SrcSpanAnn (EpAnn anc an emptyComments) l
 #else
 stripComments :: EpAnn an -> EpAnn an
+#if __GLASGOW_HASKELL__ >= 914
+stripComments e = e { comments = emptyComments }
+#else
 stripComments = removeCommentsA
+#endif
 #endif
 
 -- Move leading whitespace from the left child of an operator application

--- a/Retrie/ExactPrint/Annotated.hs
+++ b/Retrie/ExactPrint/Annotated.hs
@@ -4,6 +4,7 @@
 -- This source code is licensed under the MIT license found in the
 -- LICENSE file in the root directory of this source tree.
 --
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -149,8 +150,12 @@ trimA = runIdentity . transformA nil . const . graftA
     nil :: Annotated ()
     nil = mempty
 
+#if __GLASGOW_HASKELL__ < 912
 setEntryDPA :: (Default an)
             => Annotated (LocatedAn an ast) -> DeltaPos -> Annotated (LocatedAn an ast)
+#else
+setEntryDPA :: Annotated (LocatedAn an ast) -> DeltaPos -> Annotated (LocatedAn an ast)
+#endif
 setEntryDPA (Annotated ast s) dp = Annotated (setEntryDP ast dp) s
 
 -- | Exactprint an 'Annotated' thing.

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -51,6 +51,18 @@ mkLocatedHsVar :: Monad m => LocatedN RdrName -> TransformT m (LHsExpr GhcPs)
 mkLocatedHsVar (L l n) = do
   mkLocA (SameLine 0)  (HsVar noExtField (L (setMoveAnchor (SameLine 0) l) n))
 
+#if __GLASGOW_HASKELL__ >= 912
+-- TODO: move to ghc-exactprint
+setMoveAnchor :: (Monoid an) => DeltaPos -> EpAnn an -> EpAnn an
+setMoveAnchor dp (EpAnn (EpaSpan l) an cs)
+  = EpAnn (dpAnchor l dp) an cs
+setMoveAnchor dp (EpAnn (EpaDelta l _ _) an cs)
+  = EpAnn (dpAnchor l dp) an cs
+
+-- TODO: move to ghc-exactprint
+dpAnchor :: SrcSpan -> DeltaPos -> EpaLocation
+dpAnchor l dp = EpaDelta l dp []
+#else
 -- TODO: move to ghc-exactprint
 setMoveAnchor :: (Monoid an) => DeltaPos -> SrcAnn an -> SrcAnn an
 setMoveAnchor dp (SrcSpanAnn EpAnnNotUsed l)
@@ -61,6 +73,7 @@ setMoveAnchor dp (SrcSpanAnn (EpAnn (Anchor a _) an cs) l)
 -- TODO: move to ghc-exactprint
 dpAnchor :: SrcSpan -> DeltaPos -> Anchor
 dpAnchor l dp = Anchor (realSrcSpan l) (MovedAnchor dp)
+#endif
 
 -------------------------------------------------------------------------------
 
@@ -76,6 +89,31 @@ mkLoc :: (Data e, Monad m) => e -> TransformT m (Located e)
 mkLoc e = do
   L <$> uniqueSrcSpanT <*> pure e
 
+#if __GLASGOW_HASKELL__ >= 912
+-- ++AZ++:TODO: move to ghc-exactprint
+mkLocA :: (Data e, Monad m, Monoid an)
+  => DeltaPos -> e -> TransformT m (LocatedAn an e)
+mkLocA dp e = mkLocAA dp mempty e
+
+-- ++AZ++:TODO: move to ghc-exactprint
+mkLocAA :: (Data e, Monad m) => DeltaPos -> an -> e -> TransformT m (LocatedAn an e)
+mkLocAA dp an e = do
+  l <- uniqueSrcSpanT
+  let anc = EpaDelta l dp []
+  return (L (EpAnn anc an emptyComments) e)
+
+
+-- ++AZ++:TODO: move to ghc-exactprint
+mkEpAnn :: Monad m => DeltaPos -> an -> TransformT m (EpAnn an)
+mkEpAnn dp an = do
+  anc <- mkAnchor dp
+  return $ EpAnn anc an emptyComments
+
+mkAnchor :: Monad m => DeltaPos -> TransformT m (EpaLocation)
+mkAnchor dp = do
+  l <- uniqueSrcSpanT
+  return (EpaDelta l dp [])
+#else
 -- ++AZ++:TODO: move to ghc-exactprint
 mkLocA :: (Data e, Monad m, Monoid an)
   => DeltaPos -> e -> TransformT m (LocatedAn an e)
@@ -99,9 +137,40 @@ mkAnchor :: Monad m => DeltaPos -> TransformT m (Anchor)
 mkAnchor dp = do
   l <- uniqueSrcSpanT
   return (Anchor (realSrcSpan l) (MovedAnchor dp))
+#endif
 
 -------------------------------------------------------------------------------
 
+#if __GLASGOW_HASKELL__ >= 912
+mkLams
+  :: [LPat GhcPs]
+  -> LHsExpr GhcPs
+  -> TransformT IO (LHsExpr GhcPs)
+mkLams [] e = return e
+mkLams (p:ps) e = do
+  ancg <- mkAnchor (SameLine 1)
+  ancm <- mkAnchor (SameLine 0)
+  ancGrhs <- mkAnchor (SameLine 0)
+  let
+    rarrow = EpUniTok ancg NormalSyntax
+    ga = GrhsAnn Nothing (Right rarrow)
+    anGrhs = EpAnn ancGrhs ga emptyComments
+    
+    lamTok = EpTok ancm
+    lamAnn = EpAnnLam lamTok Nothing
+
+    -- Ensure space after lambda
+    vs' = setEntryDP p (SameLine 1) : ps
+    
+    L l (Match _ ctxt pats (GRHSs cs grhs binds)) = mkMatch (LamAlt LamSingle) (L (EpaSpan noSrcSpan) vs') e emptyLocalBinds
+    grhs' = case grhs of
+      [L lg (GRHS _ guards rhs)] -> [L lg (GRHS anGrhs guards rhs)]
+      _ -> fail "mkLams: lambda expression can only have a single grhs!"
+  matches <- mkLocA (SameLine 0) [L l (Match noExtField ctxt pats (GRHSs cs grhs' binds))]
+  let
+    mg = mkMatchGroup (Generated OtherExpansion SkipPmc) matches
+  mkLocA (SameLine 1) $ HsLam lamAnn LamSingle mg
+#else
 mkLams
   :: [LPat GhcPs]
   -> LHsExpr GhcPs
@@ -120,39 +189,54 @@ mkLams vs e = do
       _ -> fail "mkLams: lambda expression can only have a single grhs!"
   matches <- mkLocA (SameLine 0) [L l (Match anm ctxt pats (GRHSs cs grhs' binds))]
   let
-    mg =
-#if __GLASGOW_HASKELL__ < 908
-      mkMatchGroup Generated matches
-#else
-      mkMatchGroup (Generated SkipPmc) matches
-#endif
+    mg = mkMatchGroup (Generated SkipPmc) matches
   mkLocA (SameLine 1) $ HsLam noExtField mg
+#endif
 
 mkLet :: Monad m => HsLocalBinds GhcPs -> LHsExpr GhcPs -> TransformT m (LHsExpr GhcPs)
 mkLet EmptyLocalBinds{} e = return e
 mkLet lbs e = do
+#if __GLASGOW_HASKELL__ >= 912
+  letTokLoc <- mkAnchor (SameLine 0)
+  inTokLoc <- mkAnchor (DifferentLine 1 1)
+  let tokLet = EpTok letTokLoc
+      tokIn = EpTok inTokLoc
+  le <- mkLocA (SameLine 1) $ HsLet (tokLet, tokIn) lbs e
+#else
   an <- mkEpAnn (DifferentLine 1 5) NoEpAnns
   let tokLet = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
       tokIn = L (TokenLoc (EpaDelta (DifferentLine 1 1) [])) HsTok
   le <- mkLocA (SameLine 1) $ HsLet an tokLet lbs tokIn e
+#endif
   return le
 
 mkApps :: MonadIO m => LHsExpr GhcPs -> [LHsExpr GhcPs] -> TransformT m (LHsExpr GhcPs)
 mkApps e []     = return e
 mkApps f (a:as) = do
   -- lift $ liftIO $ debugPrint Loud "mkApps:f="  [showAst f]
-  f' <- mkLocA (SameLine 0) (HsApp noAnn f a)
+  let a' = setEntryDP a (SameLine 1)
+#if __GLASGOW_HASKELL__ >= 912
+  f' <- mkLocA (SameLine 0) (HsApp noExtField f a')
+#else
+  f' <- mkLocA (SameLine 0) (HsApp noAnn f a')
+#endif
   mkApps f' as
 
 -- GHC never generates HsAppTy in the parser, using HsAppsTy to keep a list
 -- of types.
 mkHsAppsTy :: Monad m => [LHsType GhcPs] -> TransformT m (LHsType GhcPs)
 mkHsAppsTy [] = error "mkHsAppsTy: empty list"
-mkHsAppsTy (t:ts) = foldM (\t1 t2 -> mkLocA (SameLine 1) (HsAppTy noExtField t1 t2)) t ts
+mkHsAppsTy (t:ts) = do
+  let t' = setEntryDP t (SameLine 0)
+  foldM (\t1 t2 -> mkLocA (SameLine 1) (HsAppTy noExtField t1 t2)) t' ts
 
 mkTyVar :: Monad m => LocatedN RdrName -> TransformT m (LHsType GhcPs)
 mkTyVar nm = do
+#if __GLASGOW_HASKELL__ >= 912
+  tv <- mkLocA (SameLine 1) (HsTyVar NoEpTok NotPromoted nm)
+#else
   tv <- mkLocA (SameLine 1) (HsTyVar noAnn NotPromoted nm)
+#endif
   -- _ <- setAnnsFor nm [(G AnnVal, DP (0,0))]
   (tv', _) <- swapEntryDPT tv nm
   return tv'
@@ -169,7 +253,11 @@ mkConPatIn
   -- -> HsConDetails Void (LocatedN RdrName) [RecordPatSynField GhcPs]
   -> TransformT m (LPat GhcPs)
 mkConPatIn patName params = do
+#if __GLASGOW_HASKELL__ >= 912
+  p <- mkLocA (SameLine 0) $ ConPat (Nothing, Nothing) patName params
+#else
   p <- mkLocA (SameLine 0) $ ConPat noAnn patName params
+#endif
   -- setEntryDPT p (DP (0,0))
   return p
 
@@ -209,7 +297,11 @@ patToExpr orig = case dLPat orig of
   Nothing -> error "patToExpr: called on unlocated Pat!"
   Just lp@(L _ p) -> do
     e <- go p
+#if __GLASGOW_HASKELL__ < 912
     lift $ transferEntryDP lp e
+#else
+    return $ transferEntryDP lp e
+#endif
   where
     -- go :: Pat GhcPs -> PatQ m (LHsExpr GhcPs)
     go WildPat{} = do
@@ -222,11 +314,41 @@ patToExpr orig = case dLPat orig of
     go (ListPat _ ps) = do
       ps' <- mapM patToExpr ps
       lift $ do
+#if __GLASGOW_HASKELL__ >= 912
+        anc1 <- mkAnchor (SameLine 0)
+        anc2 <- mkAnchor (SameLine 0)
+        let open = EpTok anc1
+            close = EpTok anc2
+            an = AnnList Nothing (ListSquare open close) [] () []
+#else
         an <- mkEpAnn (SameLine 1)
                       (AnnList Nothing (Just (AddEpAnn AnnOpenS d0)) (Just (AddEpAnn AnnCloseS d0)) [] [])
+#endif
         el <- mkLocA (SameLine 1) $ ExplicitList an ps'
         -- setAnnsFor el [(G AnnOpenS, DP (0,0)), (G AnnCloseS, DP (0,0))]
         return el
+#if __GLASGOW_HASKELL__ >= 912
+    go (LitPat _ lit) = lift $ do
+      -- lit' <- cloneT lit
+      mkLocA (SameLine 1) $ HsLit noExtField lit
+    go (NPat _ llit mbNeg _) = lift $ do
+      -- L _ lit <- cloneT llit
+      e <- mkLocA (SameLine 1) $ HsOverLit noExtField (unLoc llit)
+      case mbNeg of
+        Nothing -> return e
+        Just _ -> do
+          anc <- mkAnchor (SameLine 0)
+          let minusTok = EpTok anc
+          mkLocA (SameLine 0) (NegApp minusTok e noSyntaxExpr)
+      -- addAllAnnsT llit negE
+    go (ParPat _ p') = do
+      p <- patToExpr p'
+      anc1 <- lift $ mkAnchor (SameLine 0)
+      anc2 <- lift $ mkAnchor (SameLine 0)
+      let tokLP = EpTok anc1
+          tokRP = EpTok anc2
+      lift $ mkLocA (SameLine 1) (HsPar (tokLP, tokRP) p)
+#else
     go (LitPat _ lit) = lift $ do
       -- lit' <- cloneT lit
       mkLocA (SameLine 1) $ HsLit noAnn lit
@@ -241,11 +363,16 @@ patToExpr orig = case dLPat orig of
       let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
           tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
       lift $ mkLocA (SameLine 1) (HsPar an tokLP p tokRP)
+#endif
     go SigPat{} = error "patToExpr SigPat"
     go (TuplePat an ps boxity) = do
       es <- forM ps $ \pat -> do
         e <- patToExpr pat
+#if __GLASGOW_HASKELL__ >= 912
+        return $ Present noExtField e
+#else
         return $ Present noAnn e
+#endif
       lift $ mkLocA (SameLine 1) $ ExplicitTuple an es boxity
     go (VarPat _ i) = lift $ mkLocatedHsVar i
     go AsPat{} = error "patToExpr AsPat"
@@ -253,6 +380,11 @@ patToExpr orig = case dLPat orig of
     go SplicePat{} = error "patToExpr SplicePat"
     go SumPat{} = error "patToExpr SumPat"
     go ViewPat{} = error "patToExpr ViewPat"
+#if __GLASGOW_HASKELL__ >= 912
+    go OrPat{} = error "patToExpr OrPat"
+    go EmbTyPat{} = error "patToExpr EmbTyPat"
+    go InvisPat{} = error "patToExpr InvisPat"
+#endif
 
 conPatHelper :: MonadIO m
              => LocatedN RdrName
@@ -260,7 +392,11 @@ conPatHelper :: MonadIO m
              -> PatQ m (LHsExpr GhcPs)
 conPatHelper con (InfixCon x y) =
   lift . mkLocA (SameLine 1)
+#if __GLASGOW_HASKELL__ >= 912
+               =<< OpApp <$> pure noExtField
+#else
                =<< OpApp <$> pure noAnn
+#endif
                          <*> patToExpr x
                          <*> lift (mkLocatedHsVar con)
                          <*> patToExpr y
@@ -281,10 +417,10 @@ grhsToExpr (L _ (GRHS _ (_:_) e)) = e -- not sure about this
 -------------------------------------------------------------------------------
 
 precedence :: FixityEnv -> HsExpr GhcPs -> Maybe Fixity
-#if __GLASGOW_HASKELL__ < 908
-precedence _        (HsApp {})       = Just $ Fixity (SourceText "HsApp") 10 InfixL
+#if __GLASGOW_HASKELL__ >= 912
+precedence _        (HsApp {})       = Just $ Fixity 10 InfixL
 #else
-precedence _        (HsApp {})       = Just $ Fixity (SourceText (fsLit "HsApp")) 10 InfixL
+precedence _        (HsApp {})       = Just $ Fixity NoSourceText 10 InfixL
 #endif
 precedence fixities (OpApp _ _ op _) = Just $ lookupOp op fixities
 precedence _        _                = Nothing
@@ -293,13 +429,25 @@ parenify
   :: Monad m => Context -> LHsExpr GhcPs -> TransformT m (LHsExpr GhcPs)
 parenify Context{..} le@(L _ e)
   | needed ctxtParentPrec (precedence ctxtFixityEnv e) && needsParens e = do
-    let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-        tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-     in mkParen' (getEntryDP le) (\an -> HsPar an tokLP (setEntryDP le (SameLine 0)) tokRP)
+#if __GLASGOW_HASKELL__ >= 912
+     anc1 <- mkAnchor (SameLine 0)
+     anc2 <- mkAnchor (SameLine 0)
+     let tokLP = EpTok anc1
+         tokRP = EpTok anc2
+     mkParen' (getEntryDP le) (\_ -> HsPar (tokLP, tokRP) (setEntryDP le (SameLine 0)))
+#else
+     let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+         tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+      in mkLocA (getEntryDP le) (HsPar noAnn tokLP (setEntryDP le (SameLine 0)) tokRP)
+#endif
   | otherwise = return le
   where
            {- parent -}               {- child -}
+#if __GLASGOW_HASKELL__ >= 912
+    needed (HasPrec (Fixity p1 d1)) (Just (Fixity p2 d2)) =
+#else
     needed (HasPrec (Fixity _ p1 d1)) (Just (Fixity _ p2 d2)) =
+#endif
       p1 > p2 || (p1 == p2 && (d1 /= d2 || d2 == InfixN))
     needed NeverParen _ = False
     needed _ Nothing = True
@@ -311,7 +459,11 @@ getUnparened = mkT unparen `extT` unparenT `extT` unparenP
 -- TODO: what about comments?
 unparen :: LHsExpr GhcPs -> LHsExpr GhcPs
 unparen expr = case expr of
+#if __GLASGOW_HASKELL__ >= 912
+  L _ (HsPar _ e)
+#else
   L _ (HsPar _ _ e _)
+#endif
     -- see Note [Sections in HsSyn] in GHC.Hs.Expr
     | L _ SectionL{} <- e -> expr
     | L _ SectionR{} <- e -> expr
@@ -322,23 +474,36 @@ unparen expr = case expr of
 needsParens :: HsExpr GhcPs -> Bool
 needsParens = hsExprNeedsParens (PprPrec 10)
 
+#if __GLASGOW_HASKELL__ >= 912
 mkParen' :: (Data x, Monad m, Monoid an)
-         => DeltaPos -> (EpAnn NoEpAnns -> x) -> TransformT m (LocatedAn an x)
+         => DeltaPos -> (EpAnn AnnListItem -> x) -> TransformT m (LocatedAn an x)
 mkParen' dp k = do
-  let an = NoEpAnns
+  let an = AnnListItem []
   l <- uniqueSrcSpanT
-  let anc = Anchor (realSrcSpan l) (MovedAnchor (SameLine 0))
+  let anc = EpaDelta l dp []
   pe <- mkLocA dp (k (EpAnn anc an emptyComments))
   return pe
+#endif
 
+#if __GLASGOW_HASKELL__ >= 912
+mkParenTy :: (Data x, Monad m, Monoid an)
+         => DeltaPos -> (EpAnn AnnListItem -> x) -> TransformT m (LocatedAn an x)
+mkParenTy dp k = do
+  let an = AnnListItem []
+  l <- uniqueSrcSpanT
+  let anc = EpaDelta l dp []
+  pe <- mkLocA dp (k (EpAnn anc an emptyComments))
+  return pe
+#else
 mkParenTy :: (Data x, Monad m, Monoid an)
          => DeltaPos -> (EpAnn AnnParen -> x) -> TransformT m (LocatedAn an x)
 mkParenTy dp k = do
-  let an = AnnParen AnnParens d0 d0
+  let an = AnnParen AnnParens (EpaDelta (SameLine 0) []) (EpaDelta (SameLine 0) [])
   l <- uniqueSrcSpanT
   let anc = Anchor (realSrcSpan l) (MovedAnchor (SameLine 0))
   pe <- mkLocA dp (k (EpAnn anc an emptyComments))
   return pe
+#endif
 
 -- This explicitly operates on 'Located (Pat GhcPs)' instead of 'LPat GhcPs'
 -- because it is applied at that type by SYB.
@@ -347,13 +512,25 @@ parenifyP
   => Context
   -> LPat GhcPs
   -> TransformT m (LPat GhcPs)
+#if __GLASGOW_HASKELL__ >= 912
+parenifyP Context{..} p@(L _ pat)
+  | IsLhs <- ctxtParentPrec
+  , needed pat = do
+    anc1 <- mkAnchor (SameLine 0)
+    anc2 <- mkAnchor (SameLine 0)
+    let tokLP = EpTok anc1
+        tokRP = EpTok anc2
+    mkParen' (getEntryDP p) (\_ -> ParPat (tokLP, tokRP) p)
+  | otherwise = return p
+#else
 parenifyP Context{..} p@(L _ pat)
   | IsLhs <- ctxtParentPrec
   , needed pat =
     let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
         tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-     in mkParen' (getEntryDP p) (\an -> ParPat an tokLP (setEntryDP p (SameLine 0)) tokRP)
+     in mkLocA (getEntryDP p) (ParPat noAnn tokLP (setEntryDP p (SameLine 0)) tokRP)
   | otherwise = return p
+#endif
   where
     needed BangPat{}                          = False
     needed LazyPat{}                          = False
@@ -369,6 +546,22 @@ parenifyP Context{..} p@(L _ pat)
 
 parenifyT
   :: Monad m => Context -> LHsType GhcPs -> TransformT m (LHsType GhcPs)
+#if __GLASGOW_HASKELL__ >= 912
+parenifyT Context{..} lty@(L _ ty)
+  | needed ty = do
+      anc1 <- mkAnchor (SameLine 0)
+      anc2 <- mkAnchor (SameLine 0)
+      let tokLP = EpTok anc1
+          tokRP = EpTok anc2
+      mkParenTy (getEntryDP lty) (\_ -> HsParTy (tokLP, tokRP) (setEntryDP lty (SameLine 0)))
+  | otherwise = return lty
+  where
+    needed t = case ctxtParentPrec of
+      HasPrec (Fixity prec InfixN) -> hsTypeNeedsParens (PprPrec prec) t
+      HasPrec (Fixity prec _) -> hsTypeNeedsParens (PprPrec $ prec - 1) t
+      IsLhs -> False
+      NeverParen -> False
+#else
 parenifyT Context{..} lty@(L _ ty)
   | needed ty =
       mkParenTy (getEntryDP lty) (\an -> HsParTy an (setEntryDP lty (SameLine 0)))
@@ -376,19 +569,21 @@ parenifyT Context{..} lty@(L _ ty)
   where
     needed t = case ctxtParentPrec of
       HasPrec (Fixity _ prec InfixN) -> hsTypeNeedsParens (PprPrec prec) t
-      -- We just assume we won't have mixed 'FixityDirection's for 'HsType',
-      -- this is not true for 'HsFunTy' (@infixr 2@) and 'HsOpTy' (@infixl 2@).
-      -- Currently, we will simply always add parens around 'HsOpTy'.
       HasPrec (Fixity _ prec _) -> hsTypeNeedsParens (PprPrec $ prec - 1) t
       IsLhs -> False
       NeverParen -> False
+#endif
 
 unparenT :: LHsType GhcPs -> LHsType GhcPs
 unparenT (L _ (HsParTy _ ty)) = ty
 unparenT ty = ty
 
 unparenP :: LPat GhcPs -> LPat GhcPs
+#if __GLASGOW_HASKELL__ >= 912
+unparenP (L _ (ParPat _ p)) = p
+#else
 unparenP (L _ (ParPat _ _ p _)) = p
+#endif
 unparenP p = p
 
 --------------------------------------------------------------------

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -189,7 +189,11 @@ mkLams vs e = do
       _ -> fail "mkLams: lambda expression can only have a single grhs!"
   matches <- mkLocA (SameLine 0) [L l (Match anm ctxt pats (GRHSs cs grhs' binds))]
   let
+#if __GLASGOW_HASKELL__ < 908
+    mg = mkMatchGroup Generated matches
+#else
     mg = mkMatchGroup (Generated SkipPmc) matches
+#endif
   mkLocA (SameLine 1) $ HsLam noExtField mg
 #endif
 

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -51,18 +51,7 @@ mkLocatedHsVar :: Monad m => LocatedN RdrName -> TransformT m (LHsExpr GhcPs)
 mkLocatedHsVar (L l n) = do
   mkLocA (SameLine 0)  (HsVar noExtField (L (setMoveAnchor (SameLine 0) l) n))
 
-#if __GLASGOW_HASKELL__ >= 912
--- TODO: move to ghc-exactprint
-setMoveAnchor :: (Monoid an) => DeltaPos -> EpAnn an -> EpAnn an
-setMoveAnchor dp (EpAnn (EpaSpan l) an cs)
-  = EpAnn (dpAnchor l dp) an cs
-setMoveAnchor dp (EpAnn (EpaDelta l _ _) an cs)
-  = EpAnn (dpAnchor l dp) an cs
-
--- TODO: move to ghc-exactprint
-dpAnchor :: SrcSpan -> DeltaPos -> EpaLocation
-dpAnchor l dp = EpaDelta l dp []
-#else
+#if __GLASGOW_HASKELL__ < 912
 -- TODO: move to ghc-exactprint
 setMoveAnchor :: (Monoid an) => DeltaPos -> SrcAnn an -> SrcAnn an
 setMoveAnchor dp (SrcSpanAnn EpAnnNotUsed l)
@@ -73,6 +62,17 @@ setMoveAnchor dp (SrcSpanAnn (EpAnn (Anchor a _) an cs) l)
 -- TODO: move to ghc-exactprint
 dpAnchor :: SrcSpan -> DeltaPos -> Anchor
 dpAnchor l dp = Anchor (realSrcSpan l) (MovedAnchor dp)
+#else
+-- TODO: move to ghc-exactprint
+setMoveAnchor :: (Monoid an) => DeltaPos -> EpAnn an -> EpAnn an
+setMoveAnchor dp (EpAnn (EpaSpan l) an cs)
+  = EpAnn (dpAnchor l dp) an cs
+setMoveAnchor dp (EpAnn (EpaDelta l _ _) an cs)
+  = EpAnn (dpAnchor l dp) an cs
+
+-- TODO: move to ghc-exactprint
+dpAnchor :: SrcSpan -> DeltaPos -> EpaLocation
+dpAnchor l dp = EpaDelta l dp []
 #endif
 
 -------------------------------------------------------------------------------
@@ -89,31 +89,7 @@ mkLoc :: (Data e, Monad m) => e -> TransformT m (Located e)
 mkLoc e = do
   L <$> uniqueSrcSpanT <*> pure e
 
-#if __GLASGOW_HASKELL__ >= 912
--- ++AZ++:TODO: move to ghc-exactprint
-mkLocA :: (Data e, Monad m, Monoid an)
-  => DeltaPos -> e -> TransformT m (LocatedAn an e)
-mkLocA dp e = mkLocAA dp mempty e
-
--- ++AZ++:TODO: move to ghc-exactprint
-mkLocAA :: (Data e, Monad m) => DeltaPos -> an -> e -> TransformT m (LocatedAn an e)
-mkLocAA dp an e = do
-  l <- uniqueSrcSpanT
-  let anc = EpaDelta l dp []
-  return (L (EpAnn anc an emptyComments) e)
-
-
--- ++AZ++:TODO: move to ghc-exactprint
-mkEpAnn :: Monad m => DeltaPos -> an -> TransformT m (EpAnn an)
-mkEpAnn dp an = do
-  anc <- mkAnchor dp
-  return $ EpAnn anc an emptyComments
-
-mkAnchor :: Monad m => DeltaPos -> TransformT m (EpaLocation)
-mkAnchor dp = do
-  l <- uniqueSrcSpanT
-  return (EpaDelta l dp [])
-#else
+#if __GLASGOW_HASKELL__ < 912
 -- ++AZ++:TODO: move to ghc-exactprint
 mkLocA :: (Data e, Monad m, Monoid an)
   => DeltaPos -> e -> TransformT m (LocatedAn an e)
@@ -137,11 +113,60 @@ mkAnchor :: Monad m => DeltaPos -> TransformT m (Anchor)
 mkAnchor dp = do
   l <- uniqueSrcSpanT
   return (Anchor (realSrcSpan l) (MovedAnchor dp))
+#else
+-- ++AZ++:TODO: move to ghc-exactprint
+mkLocA :: (Data e, Monad m, Monoid an)
+  => DeltaPos -> e -> TransformT m (LocatedAn an e)
+mkLocA dp e = mkLocAA dp mempty e
+
+-- ++AZ++:TODO: move to ghc-exactprint
+mkLocAA :: (Data e, Monad m) => DeltaPos -> an -> e -> TransformT m (LocatedAn an e)
+mkLocAA dp an e = do
+  l <- uniqueSrcSpanT
+  let anc = EpaDelta l dp []
+  return (L (EpAnn anc an emptyComments) e)
+
+
+-- ++AZ++:TODO: move to ghc-exactprint
+mkEpAnn :: Monad m => DeltaPos -> an -> TransformT m (EpAnn an)
+mkEpAnn dp an = do
+  anc <- mkAnchor dp
+  return $ EpAnn anc an emptyComments
+
+mkAnchor :: Monad m => DeltaPos -> TransformT m (EpaLocation)
+mkAnchor dp = do
+  l <- uniqueSrcSpanT
+  return (EpaDelta l dp [])
 #endif
 
 -------------------------------------------------------------------------------
 
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+mkLams
+  :: [LPat GhcPs]
+  -> LHsExpr GhcPs
+  -> TransformT IO (LHsExpr GhcPs)
+mkLams [] e = return e
+mkLams vs e = do
+  ancg <- mkAnchor (SameLine 0)
+  ancm <- mkAnchor (SameLine 0)
+  let
+    ga = GrhsAnn Nothing (AddEpAnn AnnRarrow (EpaDelta (SameLine 1) []))
+    ang = EpAnn ancg ga emptyComments
+    anm = EpAnn ancm [(AddEpAnn AnnLam (EpaDelta (SameLine 0) []))] emptyComments
+    L l (Match _ ctxt pats (GRHSs cs grhs binds)) = mkMatch LambdaExpr vs e emptyLocalBinds
+    grhs' = case grhs of
+      [L lg (GRHS _ guards rhs)] -> [L lg (GRHS ang guards rhs)]
+      _ -> fail "mkLams: lambda expression can only have a single grhs!"
+  matches <- mkLocA (SameLine 0) [L l (Match anm ctxt pats (GRHSs cs grhs' binds))]
+  let
+#if __GLASGOW_HASKELL__ < 908
+    mg = mkMatchGroup Generated matches
+#else
+    mg = mkMatchGroup (Generated SkipPmc) matches
+#endif
+  mkLocA (SameLine 1) $ HsLam noExtField mg
+#else
 mkLams
   :: [LPat GhcPs]
   -> LHsExpr GhcPs
@@ -170,47 +195,22 @@ mkLams (p:ps) e = do
   let
     mg = mkMatchGroup (Generated OtherExpansion SkipPmc) matches
   mkLocA (SameLine 1) $ HsLam lamAnn LamSingle mg
-#else
-mkLams
-  :: [LPat GhcPs]
-  -> LHsExpr GhcPs
-  -> TransformT IO (LHsExpr GhcPs)
-mkLams [] e = return e
-mkLams vs e = do
-  ancg <- mkAnchor (SameLine 0)
-  ancm <- mkAnchor (SameLine 0)
-  let
-    ga = GrhsAnn Nothing (AddEpAnn AnnRarrow (EpaDelta (SameLine 1) []))
-    ang = EpAnn ancg ga emptyComments
-    anm = EpAnn ancm [(AddEpAnn AnnLam (EpaDelta (SameLine 0) []))] emptyComments
-    L l (Match _ ctxt pats (GRHSs cs grhs binds)) = mkMatch LambdaExpr vs e emptyLocalBinds
-    grhs' = case grhs of
-      [L lg (GRHS _ guards rhs)] -> [L lg (GRHS ang guards rhs)]
-      _ -> fail "mkLams: lambda expression can only have a single grhs!"
-  matches <- mkLocA (SameLine 0) [L l (Match anm ctxt pats (GRHSs cs grhs' binds))]
-  let
-#if __GLASGOW_HASKELL__ < 908
-    mg = mkMatchGroup Generated matches
-#else
-    mg = mkMatchGroup (Generated SkipPmc) matches
-#endif
-  mkLocA (SameLine 1) $ HsLam noExtField mg
 #endif
 
 mkLet :: Monad m => HsLocalBinds GhcPs -> LHsExpr GhcPs -> TransformT m (LHsExpr GhcPs)
 mkLet EmptyLocalBinds{} e = return e
 mkLet lbs e = do
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+  an <- mkEpAnn (DifferentLine 1 5) NoEpAnns
+  let tokLet = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+      tokIn = L (TokenLoc (EpaDelta (DifferentLine 1 1) [])) HsTok
+  le <- mkLocA (SameLine 1) $ HsLet an tokLet lbs tokIn e
+#else
   letTokLoc <- mkAnchor (SameLine 0)
   inTokLoc <- mkAnchor (DifferentLine 1 1)
   let tokLet = EpTok letTokLoc
       tokIn = EpTok inTokLoc
   le <- mkLocA (SameLine 1) $ HsLet (tokLet, tokIn) lbs e
-#else
-  an <- mkEpAnn (DifferentLine 1 5) NoEpAnns
-  let tokLet = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-      tokIn = L (TokenLoc (EpaDelta (DifferentLine 1 1) [])) HsTok
-  le <- mkLocA (SameLine 1) $ HsLet an tokLet lbs tokIn e
 #endif
   return le
 
@@ -219,10 +219,10 @@ mkApps e []     = return e
 mkApps f (a:as) = do
   -- lift $ liftIO $ debugPrint Loud "mkApps:f="  [showAst f]
   let a' = setEntryDP a (SameLine 1)
-#if __GLASGOW_HASKELL__ >= 912
-  f' <- mkLocA (SameLine 0) (HsApp noExtField f a')
-#else
+#if __GLASGOW_HASKELL__ < 912
   f' <- mkLocA (SameLine 0) (HsApp noAnn f a')
+#else
+  f' <- mkLocA (SameLine 0) (HsApp noExtField f a')
 #endif
   mkApps f' as
 
@@ -236,10 +236,10 @@ mkHsAppsTy (t:ts) = do
 
 mkTyVar :: Monad m => LocatedN RdrName -> TransformT m (LHsType GhcPs)
 mkTyVar nm = do
-#if __GLASGOW_HASKELL__ >= 912
-  tv <- mkLocA (SameLine 1) (HsTyVar NoEpTok NotPromoted nm)
-#else
+#if __GLASGOW_HASKELL__ < 912
   tv <- mkLocA (SameLine 1) (HsTyVar noAnn NotPromoted nm)
+#else
+  tv <- mkLocA (SameLine 1) (HsTyVar NoEpTok NotPromoted nm)
 #endif
   -- _ <- setAnnsFor nm [(G AnnVal, DP (0,0))]
   (tv', _) <- swapEntryDPT tv nm
@@ -257,10 +257,10 @@ mkConPatIn
   -- -> HsConDetails Void (LocatedN RdrName) [RecordPatSynField GhcPs]
   -> TransformT m (LPat GhcPs)
 mkConPatIn patName params = do
-#if __GLASGOW_HASKELL__ >= 912
-  p <- mkLocA (SameLine 0) $ ConPat (Nothing, Nothing) patName params
-#else
+#if __GLASGOW_HASKELL__ < 912
   p <- mkLocA (SameLine 0) $ ConPat noAnn patName params
+#else
+  p <- mkLocA (SameLine 0) $ ConPat (Nothing, Nothing) patName params
 #endif
   -- setEntryDPT p (DP (0,0))
   return p
@@ -318,20 +318,35 @@ patToExpr orig = case dLPat orig of
     go (ListPat _ ps) = do
       ps' <- mapM patToExpr ps
       lift $ do
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+        an <- mkEpAnn (SameLine 1)
+                      (AnnList Nothing (Just (AddEpAnn AnnOpenS d0)) (Just (AddEpAnn AnnCloseS d0)) [] [])
+#else
         anc1 <- mkAnchor (SameLine 0)
         anc2 <- mkAnchor (SameLine 0)
         let open = EpTok anc1
             close = EpTok anc2
             an = AnnList Nothing (ListSquare open close) [] () []
-#else
-        an <- mkEpAnn (SameLine 1)
-                      (AnnList Nothing (Just (AddEpAnn AnnOpenS d0)) (Just (AddEpAnn AnnCloseS d0)) [] [])
 #endif
         el <- mkLocA (SameLine 1) $ ExplicitList an ps'
         -- setAnnsFor el [(G AnnOpenS, DP (0,0)), (G AnnCloseS, DP (0,0))]
         return el
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+    go (LitPat _ lit) = lift $ do
+      -- lit' <- cloneT lit
+      mkLocA (SameLine 1) $ HsLit noAnn lit
+    go (NPat _ llit mbNeg _) = lift $ do
+      -- L _ lit <- cloneT llit
+      e <- mkLocA (SameLine 1) $ HsOverLit noAnn (unLoc llit)
+      negE <- maybe (return e) (mkLocA (SameLine 0) . NegApp noAnn e) mbNeg
+      -- addAllAnnsT llit negE
+      return negE
+    go (ParPat an _ p' _) = do
+      p <- patToExpr p'
+      let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+          tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+      lift $ mkLocA (SameLine 1) (HsPar an tokLP p tokRP)
+#else
     go (LitPat _ lit) = lift $ do
       -- lit' <- cloneT lit
       mkLocA (SameLine 1) $ HsLit noExtField lit
@@ -352,30 +367,15 @@ patToExpr orig = case dLPat orig of
       let tokLP = EpTok anc1
           tokRP = EpTok anc2
       lift $ mkLocA (SameLine 1) (HsPar (tokLP, tokRP) p)
-#else
-    go (LitPat _ lit) = lift $ do
-      -- lit' <- cloneT lit
-      mkLocA (SameLine 1) $ HsLit noAnn lit
-    go (NPat _ llit mbNeg _) = lift $ do
-      -- L _ lit <- cloneT llit
-      e <- mkLocA (SameLine 1) $ HsOverLit noAnn (unLoc llit)
-      negE <- maybe (return e) (mkLocA (SameLine 0) . NegApp noAnn e) mbNeg
-      -- addAllAnnsT llit negE
-      return negE
-    go (ParPat an _ p' _) = do
-      p <- patToExpr p'
-      let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-          tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-      lift $ mkLocA (SameLine 1) (HsPar an tokLP p tokRP)
 #endif
     go SigPat{} = error "patToExpr SigPat"
     go (TuplePat an ps boxity) = do
       es <- forM ps $ \pat -> do
         e <- patToExpr pat
-#if __GLASGOW_HASKELL__ >= 912
-        return $ Present noExtField e
-#else
+#if __GLASGOW_HASKELL__ < 912
         return $ Present noAnn e
+#else
+        return $ Present noExtField e
 #endif
       lift $ mkLocA (SameLine 1) $ ExplicitTuple an es boxity
     go (VarPat _ i) = lift $ mkLocatedHsVar i
@@ -384,7 +384,8 @@ patToExpr orig = case dLPat orig of
     go SplicePat{} = error "patToExpr SplicePat"
     go SumPat{} = error "patToExpr SumPat"
     go ViewPat{} = error "patToExpr ViewPat"
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+#else
     go OrPat{} = error "patToExpr OrPat"
     go EmbTyPat{} = error "patToExpr EmbTyPat"
     go InvisPat{} = error "patToExpr InvisPat"
@@ -396,10 +397,10 @@ conPatHelper :: MonadIO m
              -> PatQ m (LHsExpr GhcPs)
 conPatHelper con (InfixCon x y) =
   lift . mkLocA (SameLine 1)
-#if __GLASGOW_HASKELL__ >= 912
-               =<< OpApp <$> pure noExtField
-#else
+#if __GLASGOW_HASKELL__ < 912
                =<< OpApp <$> pure noAnn
+#else
+               =<< OpApp <$> pure noExtField
 #endif
                          <*> patToExpr x
                          <*> lift (mkLocatedHsVar con)
@@ -421,10 +422,10 @@ grhsToExpr (L _ (GRHS _ (_:_) e)) = e -- not sure about this
 -------------------------------------------------------------------------------
 
 precedence :: FixityEnv -> HsExpr GhcPs -> Maybe Fixity
-#if __GLASGOW_HASKELL__ >= 912
-precedence _        (HsApp {})       = Just $ Fixity 10 InfixL
-#else
+#if __GLASGOW_HASKELL__ < 912
 precedence _        (HsApp {})       = Just $ Fixity NoSourceText 10 InfixL
+#else
+precedence _        (HsApp {})       = Just $ Fixity 10 InfixL
 #endif
 precedence fixities (OpApp _ _ op _) = Just $ lookupOp op fixities
 precedence _        _                = Nothing
@@ -433,24 +434,24 @@ parenify
   :: Monad m => Context -> LHsExpr GhcPs -> TransformT m (LHsExpr GhcPs)
 parenify Context{..} le@(L _ e)
   | needed ctxtParentPrec (precedence ctxtFixityEnv e) && needsParens e = do
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+     let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+         tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+      in mkLocA (getEntryDP le) (HsPar noAnn tokLP (setEntryDP le (SameLine 0)) tokRP)
+#else
      anc1 <- mkAnchor (SameLine 0)
      anc2 <- mkAnchor (SameLine 0)
      let tokLP = EpTok anc1
          tokRP = EpTok anc2
      mkParen' (getEntryDP le) (\_ -> HsPar (tokLP, tokRP) (setEntryDP le (SameLine 0)))
-#else
-     let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-         tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-      in mkLocA (getEntryDP le) (HsPar noAnn tokLP (setEntryDP le (SameLine 0)) tokRP)
 #endif
   | otherwise = return le
   where
            {- parent -}               {- child -}
-#if __GLASGOW_HASKELL__ >= 912
-    needed (HasPrec (Fixity p1 d1)) (Just (Fixity p2 d2)) =
-#else
+#if __GLASGOW_HASKELL__ < 912
     needed (HasPrec (Fixity _ p1 d1)) (Just (Fixity _ p2 d2)) =
+#else
+    needed (HasPrec (Fixity p1 d1)) (Just (Fixity p2 d2)) =
 #endif
       p1 > p2 || (p1 == p2 && (d1 /= d2 || d2 == InfixN))
     needed NeverParen _ = False
@@ -463,10 +464,10 @@ getUnparened = mkT unparen `extT` unparenT `extT` unparenP
 -- TODO: what about comments?
 unparen :: LHsExpr GhcPs -> LHsExpr GhcPs
 unparen expr = case expr of
-#if __GLASGOW_HASKELL__ >= 912
-  L _ (HsPar _ e)
-#else
+#if __GLASGOW_HASKELL__ < 912
   L _ (HsPar _ _ e _)
+#else
+  L _ (HsPar _ e)
 #endif
     -- see Note [Sections in HsSyn] in GHC.Hs.Expr
     | L _ SectionL{} <- e -> expr
@@ -478,7 +479,8 @@ unparen expr = case expr of
 needsParens :: HsExpr GhcPs -> Bool
 needsParens = hsExprNeedsParens (PprPrec 10)
 
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+#else
 mkParen' :: (Data x, Monad m, Monoid an)
          => DeltaPos -> (EpAnn AnnListItem -> x) -> TransformT m (LocatedAn an x)
 mkParen' dp k = do
@@ -489,22 +491,22 @@ mkParen' dp k = do
   return pe
 #endif
 
-#if __GLASGOW_HASKELL__ >= 912
-mkParenTy :: (Data x, Monad m, Monoid an)
-         => DeltaPos -> (EpAnn AnnListItem -> x) -> TransformT m (LocatedAn an x)
-mkParenTy dp k = do
-  let an = AnnListItem []
-  l <- uniqueSrcSpanT
-  let anc = EpaDelta l dp []
-  pe <- mkLocA dp (k (EpAnn anc an emptyComments))
-  return pe
-#else
+#if __GLASGOW_HASKELL__ < 912
 mkParenTy :: (Data x, Monad m, Monoid an)
          => DeltaPos -> (EpAnn AnnParen -> x) -> TransformT m (LocatedAn an x)
 mkParenTy dp k = do
   let an = AnnParen AnnParens (EpaDelta (SameLine 0) []) (EpaDelta (SameLine 0) [])
   l <- uniqueSrcSpanT
   let anc = Anchor (realSrcSpan l) (MovedAnchor (SameLine 0))
+  pe <- mkLocA dp (k (EpAnn anc an emptyComments))
+  return pe
+#else
+mkParenTy :: (Data x, Monad m, Monoid an)
+         => DeltaPos -> (EpAnn AnnListItem -> x) -> TransformT m (LocatedAn an x)
+mkParenTy dp k = do
+  let an = AnnListItem []
+  l <- uniqueSrcSpanT
+  let anc = EpaDelta l dp []
   pe <- mkLocA dp (k (EpAnn anc an emptyComments))
   return pe
 #endif
@@ -516,7 +518,15 @@ parenifyP
   => Context
   -> LPat GhcPs
   -> TransformT m (LPat GhcPs)
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+parenifyP Context{..} p@(L _ pat)
+  | IsLhs <- ctxtParentPrec
+  , needed pat =
+    let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+        tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+     in mkLocA (getEntryDP p) (ParPat noAnn tokLP (setEntryDP p (SameLine 0)) tokRP)
+  | otherwise = return p
+#else
 parenifyP Context{..} p@(L _ pat)
   | IsLhs <- ctxtParentPrec
   , needed pat = do
@@ -525,14 +535,6 @@ parenifyP Context{..} p@(L _ pat)
     let tokLP = EpTok anc1
         tokRP = EpTok anc2
     mkParen' (getEntryDP p) (\_ -> ParPat (tokLP, tokRP) p)
-  | otherwise = return p
-#else
-parenifyP Context{..} p@(L _ pat)
-  | IsLhs <- ctxtParentPrec
-  , needed pat =
-    let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-        tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
-     in mkLocA (getEntryDP p) (ParPat noAnn tokLP (setEntryDP p (SameLine 0)) tokRP)
   | otherwise = return p
 #endif
   where
@@ -550,7 +552,18 @@ parenifyP Context{..} p@(L _ pat)
 
 parenifyT
   :: Monad m => Context -> LHsType GhcPs -> TransformT m (LHsType GhcPs)
-#if __GLASGOW_HASKELL__ >= 912
+#if __GLASGOW_HASKELL__ < 912
+parenifyT Context{..} lty@(L _ ty)
+  | needed ty =
+      mkParenTy (getEntryDP lty) (\an -> HsParTy an (setEntryDP lty (SameLine 0)))
+  | otherwise = return lty
+  where
+    needed t = case ctxtParentPrec of
+      HasPrec (Fixity _ prec InfixN) -> hsTypeNeedsParens (PprPrec prec) t
+      HasPrec (Fixity _ prec _) -> hsTypeNeedsParens (PprPrec $ prec - 1) t
+      IsLhs -> False
+      NeverParen -> False
+#else
 parenifyT Context{..} lty@(L _ ty)
   | needed ty = do
       anc1 <- mkAnchor (SameLine 0)
@@ -565,17 +578,6 @@ parenifyT Context{..} lty@(L _ ty)
       HasPrec (Fixity prec _) -> hsTypeNeedsParens (PprPrec $ prec - 1) t
       IsLhs -> False
       NeverParen -> False
-#else
-parenifyT Context{..} lty@(L _ ty)
-  | needed ty =
-      mkParenTy (getEntryDP lty) (\an -> HsParTy an (setEntryDP lty (SameLine 0)))
-  | otherwise = return lty
-  where
-    needed t = case ctxtParentPrec of
-      HasPrec (Fixity _ prec InfixN) -> hsTypeNeedsParens (PprPrec prec) t
-      HasPrec (Fixity _ prec _) -> hsTypeNeedsParens (PprPrec $ prec - 1) t
-      IsLhs -> False
-      NeverParen -> False
 #endif
 
 unparenT :: LHsType GhcPs -> LHsType GhcPs
@@ -583,10 +585,10 @@ unparenT (L _ (HsParTy _ ty)) = ty
 unparenT ty = ty
 
 unparenP :: LPat GhcPs -> LPat GhcPs
-#if __GLASGOW_HASKELL__ >= 912
-unparenP (L _ (ParPat _ p)) = p
-#else
+#if __GLASGOW_HASKELL__ < 912
 unparenP (L _ (ParPat _ _ p _)) = p
+#else
+unparenP (L _ (ParPat _ p)) = p
 #endif
 unparenP p = p
 

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -38,6 +38,9 @@ module Retrie.Expr
 
 import Control.Monad
 import Control.Monad.State.Lazy
+#if __GLASGOW_HASKELL__ >= 914
+import qualified Data.List.NonEmpty as NE
+#endif
 
 import Retrie.ExactPrint
 import Retrie.Fixity
@@ -188,9 +191,15 @@ mkLams (p:ps) e = do
     vs' = setEntryDP p (SameLine 1) : ps
     
     L l (Match _ ctxt pats (GRHSs cs grhs binds)) = mkMatch (LamAlt LamSingle) (L (EpaSpan noSrcSpan) vs') e emptyLocalBinds
+#if __GLASGOW_HASKELL__ >= 914
+    grhs' = case grhs of
+      (L lg (GRHS _ guards rhs) NE.:| []) -> L lg (GRHS anGrhs guards rhs) NE.:| []
+      _ -> error "mkLams: lambda expression can only have a single grhs!"
+#else
     grhs' = case grhs of
       [L lg (GRHS _ guards rhs)] -> [L lg (GRHS anGrhs guards rhs)]
       _ -> fail "mkLams: lambda expression can only have a single grhs!"
+#endif
   matches <- mkLocA (SameLine 0) [L l (Match noExtField ctxt pats (GRHSs cs grhs' binds))]
   let
     mg = mkMatchGroup (Generated OtherExpansion SkipPmc) matches
@@ -405,8 +414,12 @@ conPatHelper con (InfixCon x y) =
                          <*> patToExpr x
                          <*> lift (mkLocatedHsVar con)
                          <*> patToExpr y
+#if __GLASGOW_HASKELL__ >= 914
+conPatHelper con (PrefixCon xs) = do
+#else
 -- TODO(xich): Properly handle tyargs here!
 conPatHelper con (PrefixCon _tyargs xs) = do
+#endif
   f <- lift $ mkLocatedHsVar con
   as <- mapM patToExpr xs
   -- lift $ lift $ liftIO $ debugPrint Loud "conPatHelper:f="  [showAst f]
@@ -547,7 +560,11 @@ parenifyP Context{..} p@(L _ pat)
     needed TuplePat{}                         = False
     needed VarPat{}                           = False
     needed WildPat{}                          = False
+#if __GLASGOW_HASKELL__ >= 914
+    needed (ConPat _ _ (PrefixCon []))        = False
+#else
     needed (ConPat _ _ (PrefixCon _ []))      = False
+#endif
     needed _                                  = True
 
 parenifyT
@@ -594,6 +611,20 @@ unparenP p = p
 
 --------------------------------------------------------------------
 
+#if __GLASGOW_HASKELL__ >= 914
+bitraverseHsConDetails
+  :: Applicative m
+  => (arg -> m arg')
+  -> (rec -> m rec')
+  -> HsConDetails arg rec
+  -> m (HsConDetails arg' rec')
+bitraverseHsConDetails argf _ (PrefixCon args) =
+  PrefixCon <$> (argf `traverse` args)
+bitraverseHsConDetails _ recf (RecCon r) =
+  RecCon <$> recf r
+bitraverseHsConDetails argf _ (InfixCon a1 a2) =
+  InfixCon <$> argf a1 <*> argf a2
+#else
 bitraverseHsConDetails
   :: Applicative m
   => ([tyarg] -> m [tyarg'])
@@ -607,3 +638,4 @@ bitraverseHsConDetails _ _ recf (RecCon r) =
   RecCon <$> recf r
 bitraverseHsConDetails _ argf _ (InfixCon a1 a2) =
   InfixCon <$> argf a1 <*> argf a2
+#endif

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -414,14 +414,14 @@ conPatHelper con (InfixCon x y) =
                          <*> patToExpr x
                          <*> lift (mkLocatedHsVar con)
                          <*> patToExpr y
-#if __GLASGOW_HASKELL__ >= 914
-conPatHelper con (PrefixCon xs) = do
-#else
+#if __GLASGOW_HASKELL__ < 914
 -- TODO(xich): Properly handle tyargs here!
 conPatHelper con (PrefixCon _tyargs xs) = do
+#else
+conPatHelper con (PrefixCon xs) = do
 #endif
   f <- lift $ mkLocatedHsVar con
-  as <- mapM patToExpr xs
+  as <- mapM patToExpr $ dropInvisPats xs
   -- lift $ lift $ liftIO $ debugPrint Loud "conPatHelper:f="  [showAst f]
   lift $ mkApps f as
 conPatHelper _ _ = error "conPatHelper RecCon"

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -5,6 +5,7 @@
 -- LICENSE file in the root directory of this source tree.
 --
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
@@ -38,10 +39,6 @@ module Retrie.Expr
 
 import Control.Monad
 import Control.Monad.State.Lazy
-#if __GLASGOW_HASKELL__ < 914
-#else
-import qualified Data.List.NonEmpty as NE
-#endif
 
 import Retrie.ExactPrint
 import Retrie.Fixity
@@ -192,15 +189,9 @@ mkLams (p:ps) e = do
     vs' = setEntryDP p (SameLine 1) : ps
     
     L l (Match _ ctxt pats (GRHSs cs grhs binds)) = mkMatch (LamAlt LamSingle) (L (EpaSpan noSrcSpan) vs') e emptyLocalBinds
-#if __GLASGOW_HASKELL__ < 914
     grhs' = case grhs of
       [L lg (GRHS _ guards rhs)] -> [L lg (GRHS anGrhs guards rhs)]
-      _ -> fail "mkLams: lambda expression can only have a single grhs!"
-#else
-    grhs' = case grhs of
-      (L lg (GRHS _ guards rhs) NE.:| []) -> L lg (GRHS anGrhs guards rhs) NE.:| []
       _ -> error "mkLams: lambda expression can only have a single grhs!"
-#endif
   matches <- mkLocA (SameLine 0) [L l (Match noExtField ctxt pats (GRHSs cs grhs' binds))]
   let
     mg = mkMatchGroup (Generated OtherExpansion SkipPmc) matches

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -38,7 +38,8 @@ module Retrie.Expr
 
 import Control.Monad
 import Control.Monad.State.Lazy
-#if __GLASGOW_HASKELL__ >= 914
+#if __GLASGOW_HASKELL__ < 914
+#else
 import qualified Data.List.NonEmpty as NE
 #endif
 
@@ -191,14 +192,14 @@ mkLams (p:ps) e = do
     vs' = setEntryDP p (SameLine 1) : ps
     
     L l (Match _ ctxt pats (GRHSs cs grhs binds)) = mkMatch (LamAlt LamSingle) (L (EpaSpan noSrcSpan) vs') e emptyLocalBinds
-#if __GLASGOW_HASKELL__ >= 914
-    grhs' = case grhs of
-      (L lg (GRHS _ guards rhs) NE.:| []) -> L lg (GRHS anGrhs guards rhs) NE.:| []
-      _ -> error "mkLams: lambda expression can only have a single grhs!"
-#else
+#if __GLASGOW_HASKELL__ < 914
     grhs' = case grhs of
       [L lg (GRHS _ guards rhs)] -> [L lg (GRHS anGrhs guards rhs)]
       _ -> fail "mkLams: lambda expression can only have a single grhs!"
+#else
+    grhs' = case grhs of
+      (L lg (GRHS _ guards rhs) NE.:| []) -> L lg (GRHS anGrhs guards rhs) NE.:| []
+      _ -> error "mkLams: lambda expression can only have a single grhs!"
 #endif
   matches <- mkLocA (SameLine 0) [L l (Match noExtField ctxt pats (GRHSs cs grhs' binds))]
   let
@@ -560,10 +561,10 @@ parenifyP Context{..} p@(L _ pat)
     needed TuplePat{}                         = False
     needed VarPat{}                           = False
     needed WildPat{}                          = False
-#if __GLASGOW_HASKELL__ >= 914
-    needed (ConPat _ _ (PrefixCon []))        = False
-#else
+#if __GLASGOW_HASKELL__ < 914
     needed (ConPat _ _ (PrefixCon _ []))      = False
+#else
+    needed (ConPat _ _ (PrefixCon []))        = False
 #endif
     needed _                                  = True
 
@@ -611,20 +612,7 @@ unparenP p = p
 
 --------------------------------------------------------------------
 
-#if __GLASGOW_HASKELL__ >= 914
-bitraverseHsConDetails
-  :: Applicative m
-  => (arg -> m arg')
-  -> (rec -> m rec')
-  -> HsConDetails arg rec
-  -> m (HsConDetails arg' rec')
-bitraverseHsConDetails argf _ (PrefixCon args) =
-  PrefixCon <$> (argf `traverse` args)
-bitraverseHsConDetails _ recf (RecCon r) =
-  RecCon <$> recf r
-bitraverseHsConDetails argf _ (InfixCon a1 a2) =
-  InfixCon <$> argf a1 <*> argf a2
-#else
+#if __GLASGOW_HASKELL__ < 914
 bitraverseHsConDetails
   :: Applicative m
   => ([tyarg] -> m [tyarg'])
@@ -637,5 +625,18 @@ bitraverseHsConDetails argt argf _ (PrefixCon tyargs args) =
 bitraverseHsConDetails _ _ recf (RecCon r) =
   RecCon <$> recf r
 bitraverseHsConDetails _ argf _ (InfixCon a1 a2) =
+  InfixCon <$> argf a1 <*> argf a2
+#else
+bitraverseHsConDetails
+  :: Applicative m
+  => (arg -> m arg')
+  -> (rec -> m rec')
+  -> HsConDetails arg rec
+  -> m (HsConDetails arg' rec')
+bitraverseHsConDetails argf _ (PrefixCon args) =
+  PrefixCon <$> (argf `traverse` args)
+bitraverseHsConDetails _ recf (RecCon r) =
+  RecCon <$> recf r
+bitraverseHsConDetails argf _ (InfixCon a1 a2) =
   InfixCon <$> argf a1 <*> argf a2
 #endif

--- a/Retrie/Fixity.hs
+++ b/Retrie/Fixity.hs
@@ -4,6 +4,7 @@
 -- This source code is licensed under the MIT license found in the
 -- LICENSE file in the root directory of this source tree.
 --
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 module Retrie.Fixity
   ( FixityEnv
@@ -46,7 +47,11 @@ extendFixityEnv l (FixityEnv env) =
 ppFixityEnv :: FixityEnv -> String
 ppFixityEnv = unlines . map ppFixity . nonDetEltsUFM . unFixityEnv
   where
+#if __GLASGOW_HASKELL__ < 912
     ppFixity (fs, Fixity _ p d) = unwords
+#else
+    ppFixity (fs, Fixity p d) = unwords
+#endif
       [ case d of
           InfixN -> "infix"
           InfixL -> "infixl"

--- a/Retrie/GHC.hs
+++ b/Retrie/GHC.hs
@@ -71,6 +71,13 @@ dLPat = Just
 dLPatUnsafe :: LPat (GhcPass p) -> LPat (GhcPass p)
 dLPatUnsafe = id
 
+getMatchPats :: Match GhcPs (LHsExpr GhcPs) -> [LPat GhcPs]
+#if __GLASGOW_HASKELL__ < 912
+getMatchPats = m_pats
+#else
+getMatchPats = unLoc . m_pats
+#endif
+
 rdrFS :: RdrName -> FastString
 rdrFS (Qual m n) = mconcat [moduleNameFS m, fsDot, occNameFS n]
 rdrFS rdr = occNameFS (occName rdr)

--- a/Retrie/GHC.hs
+++ b/Retrie/GHC.hs
@@ -104,6 +104,26 @@ tyvarRdrName :: HsType p -> Maybe (LIdP p)
 tyvarRdrName (HsTyVar _ _ n) = Just n
 tyvarRdrName _ = Nothing
 
+-- | On GHC >= 9.14 constructor-pattern type arguments are invisible
+-- patterns in the PrefixCon argument list rather than a separate tyargs
+-- field. Retrie ignores them, as it ignored the tyargs field on older GHCs.
+-- TODO: Handle this case properly.
+dropInvisPats :: [LPat GhcPs] -> [LPat GhcPs]
+dropInvisPats = filter (not . isInvis)
+  where
+#if __GLASGOW_HASKELL__ < 912
+#else
+    isInvis (L _ InvisPat{}) = True
+#endif
+    isInvis _ = False
+
+grhssList :: GRHSs GhcPs body -> [LGRHS GhcPs body]
+#if __GLASGOW_HASKELL__ < 914
+grhssList = grhssGRHSs
+#else
+grhssList = NE.toList . grhssGRHSs
+#endif
+
 -- fixityDecls :: HsModule -> [(LIdP p, Fixity)]
 fixityDecls :: HsModule GhcPs -> [(LocatedN RdrName, Fixity)]
 fixityDecls m =

--- a/Retrie/GHC.hs
+++ b/Retrie/GHC.hs
@@ -110,13 +110,11 @@ tyvarRdrName _ = Nothing
 -- field. Retrie ignores them, as it ignored the tyargs field on older GHCs.
 -- TODO: Handle this case properly.
 dropInvisPats :: [LPat GhcPs] -> [LPat GhcPs]
-dropInvisPats = filter (not . isInvis)
-  where
-#if __GLASGOW_HASKELL__ < 912
+#if __GLASGOW_HASKELL__ < 914
+dropInvisPats = id
 #else
-    isInvis (L _ InvisPat{}) = True
+dropInvisPats = dropHsConPatTyArgs
 #endif
-    isInvis _ = False
 
 grhssList :: GRHSs GhcPs body -> [LGRHS GhcPs body]
 #if __GLASGOW_HASKELL__ < 914

--- a/Retrie/GHC.hs
+++ b/Retrie/GHC.hs
@@ -58,6 +58,9 @@ import Language.Haskell.Syntax.Basic as GHC.Unit.Module.Name
 import GHC.Utils.Outputable (Outputable (ppr))
 
 import Data.Bifunctor (second)
+#if __GLASGOW_HASKELL__ >= 914
+import qualified Data.List.NonEmpty as NE
+#endif
 import Data.Maybe
 
 cLPat :: LPat (GhcPass p) -> LPat (GhcPass p)
@@ -85,11 +88,19 @@ rdrFS rdr = occNameFS (occName rdr)
 fsDot :: FastString
 fsDot = mkFastString "."
 
+#if __GLASGOW_HASKELL__ >= 914
+varRdrName :: HsExpr p -> Maybe (LIdOccP p)
+#else
 varRdrName :: HsExpr p -> Maybe (LIdP p)
+#endif
 varRdrName (HsVar _ n) = Just n
 varRdrName _ = Nothing
 
+#if __GLASGOW_HASKELL__ >= 914
+tyvarRdrName :: HsType p -> Maybe (LIdOccP p)
+#else
 tyvarRdrName :: HsType p -> Maybe (LIdP p)
+#endif
 tyvarRdrName (HsTyVar _ _ n) = Just n
 tyvarRdrName _ = Nothing
 
@@ -102,7 +113,11 @@ fixityDecls m =
   ]
 
 ruleInfo :: RuleDecl GhcPs -> [RuleInfo]
+#if __GLASGOW_HASKELL__ >= 914
+ruleInfo (HsRule _ (L _ riName) _ (RuleBndrs _ tyBs valBs) riLHS riRHS) =
+#else
 ruleInfo (HsRule _ (L _ riName) _ tyBs valBs riLHS riRHS) =
+#endif
   let
     riQuantifiers =
       map unLoc (tyBindersToLocatedRdrNames (fromMaybe [] tyBs)) ++

--- a/Retrie/GHC.hs
+++ b/Retrie/GHC.hs
@@ -58,7 +58,8 @@ import Language.Haskell.Syntax.Basic as GHC.Unit.Module.Name
 import GHC.Utils.Outputable (Outputable (ppr))
 
 import Data.Bifunctor (second)
-#if __GLASGOW_HASKELL__ >= 914
+#if __GLASGOW_HASKELL__ < 914
+#else
 import qualified Data.List.NonEmpty as NE
 #endif
 import Data.Maybe
@@ -88,18 +89,18 @@ rdrFS rdr = occNameFS (occName rdr)
 fsDot :: FastString
 fsDot = mkFastString "."
 
-#if __GLASGOW_HASKELL__ >= 914
-varRdrName :: HsExpr p -> Maybe (LIdOccP p)
-#else
+#if __GLASGOW_HASKELL__ < 914
 varRdrName :: HsExpr p -> Maybe (LIdP p)
+#else
+varRdrName :: HsExpr p -> Maybe (LIdOccP p)
 #endif
 varRdrName (HsVar _ n) = Just n
 varRdrName _ = Nothing
 
-#if __GLASGOW_HASKELL__ >= 914
-tyvarRdrName :: HsType p -> Maybe (LIdOccP p)
-#else
+#if __GLASGOW_HASKELL__ < 914
 tyvarRdrName :: HsType p -> Maybe (LIdP p)
+#else
+tyvarRdrName :: HsType p -> Maybe (LIdOccP p)
 #endif
 tyvarRdrName (HsTyVar _ _ n) = Just n
 tyvarRdrName _ = Nothing
@@ -133,10 +134,10 @@ fixityDecls m =
   ]
 
 ruleInfo :: RuleDecl GhcPs -> [RuleInfo]
-#if __GLASGOW_HASKELL__ >= 914
-ruleInfo (HsRule _ (L _ riName) _ (RuleBndrs _ tyBs valBs) riLHS riRHS) =
-#else
+#if __GLASGOW_HASKELL__ < 914
 ruleInfo (HsRule _ (L _ riName) _ tyBs valBs riLHS riRHS) =
+#else
+ruleInfo (HsRule _ (L _ riName) _ (RuleBndrs _ tyBs valBs) riLHS riRHS) =
 #endif
   let
     riQuantifiers =

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -1205,7 +1205,7 @@ extractBinderInfo = go . unLoc
 #if __GLASGOW_HASKELL__ < 912
     go (UserTyVar _ _ v) = (unLoc v, Nothing)
     go (KindedTyVar _ _ v k) = (unLoc v, Just k)
-    go (XTyVarBndr _) = error "extractBinderInfo: XTyVarBndr unsupported"
+    go (XTyVarBndr _) = missingSyntax "XTyVarBndr"
 #else
     go HsTvb{..} =
       case tvb_var of
@@ -1213,9 +1213,9 @@ extractBinderInfo = go . unLoc
             case tvb_kind of
               HsBndrKind _ lkind -> (unLoc rdr, Just lkind)
               _ -> (unLoc rdr, Nothing)
-        HsBndrWildCard _ -> error "extractBinderInfo: wildcard tyvars unsupported!"
-        XBndrVar _ -> error "extractBinderInfo: XBndrVar impossible!"
-    go XTyVarBndr{} = error "extractBinderInfo: XTyVarBndr impossible!"
+        HsBndrWildCard _ -> missingSyntax "HsBndrWildCard"
+        XBndrVar _ -> missingSyntax "XBndrVar"
+    go XTyVarBndr{} = missingSyntax "XTyVarBndr"
 #endif
 
 ------------------------------------------------------------------------

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -646,11 +646,7 @@ instance PatternMap MMap where
   mAlter :: AlphaEnv -> Quantifiers -> Key MMap -> A a -> MMap a -> MMap a
   mAlter env vs match f (MMap m) =
     let
-#if __GLASGOW_HASKELL__ < 912
-      lpats = m_pats match
-#else
-      lpats = unLoc (m_pats match)
-#endif
+      lpats = getMatchPats match
       pbs = collectPatsBinders CollNoDictBinders lpats
       env' = foldr extendAlphaEnvInternal env pbs
       vs' = vs `exceptQ` pbs
@@ -660,11 +656,7 @@ instance PatternMap MMap where
   mMatch :: MatchEnv -> Key MMap -> (Substitution, MMap a) -> [(Substitution, a)]
   mMatch env match = mapFor unMMap >=> mMatch env lpats >=> mMatch env' (m_grhss match)
     where
-#if __GLASGOW_HASKELL__ < 912
-      lpats = m_pats match
-#else
-      lpats = unLoc (m_pats match)
-#endif
+      lpats = getMatchPats match
       pbs = collectPatsBinders CollNoDictBinders lpats
       env' = extendMatchEnv env pbs
 

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -411,10 +411,10 @@ instance PatternMap EMap where
       go HsPragE{} = missingSyntax "HsPragE"
       go HsTypedBracket{} = missingSyntax "HsTypedBracket"
       go HsUntypedBracket{} = missingSyntax "HsUntypedBracket"
-#if __GLASGOW_HASKELL__ >= 914
-      go HsHole{} = missingSyntax "HsHole"
-#else
+#if __GLASGOW_HASKELL__ < 914
       go HsUnboundVar{} = missingSyntax "HsUnboundVar"
+#else
+      go HsHole{} = missingSyntax "HsHole"
 #endif
       go HsOverLabel{} = missingSyntax "HsOverLabel"
       go HsAppType{} = missingSyntax "HsAppType"
@@ -680,10 +680,10 @@ emptyCDMapWrapper :: CDMap a
 emptyCDMapWrapper = CDMap mEmpty mEmpty
 
 instance PatternMap CDMap where
-#if __GLASGOW_HASKELL__ >= 914
-  type Key CDMap = HsConDetails (LocatedA (Pat GhcPs)) (HsRecFields GhcPs (LocatedA (Pat GhcPs)))
-#else
+#if __GLASGOW_HASKELL__ < 914
   type Key CDMap = HsConDetails (HsConPatTyArg GhcPs) (LocatedA (Pat GhcPs)) (HsRecFields GhcPs (LocatedA (Pat GhcPs)))
+#else
+  type Key CDMap = HsConDetails (LocatedA (Pat GhcPs)) (HsRecFields GhcPs (LocatedA (Pat GhcPs)))
 #endif
 
   mEmpty :: CDMap a
@@ -701,11 +701,11 @@ instance PatternMap CDMap where
   mAlter env vs d f CDEmpty   = mAlter env vs d f emptyCDMapWrapper
   mAlter env vs d f m@CDMap{} = go d
     where
-#if __GLASGOW_HASKELL__ >= 914
-      go (PrefixCon ps) = m { cdPrefixCon = mAlter env vs (dropInvisPats ps) f (cdPrefixCon m) }
-#else
+#if __GLASGOW_HASKELL__ < 914
       -- TODO(xich): properly handle tyargs here!
       go (PrefixCon _tyargs ps) = m { cdPrefixCon = mAlter env vs ps f (cdPrefixCon m) }
+#else
+      go (PrefixCon ps) = m { cdPrefixCon = mAlter env vs (dropInvisPats ps) f (cdPrefixCon m) }
 #endif
       go (RecCon _) = missingSyntax "RecCon"
       go (InfixCon p1 p2) = m { cdInfixCon = mAlter env vs p1
@@ -716,11 +716,11 @@ instance PatternMap CDMap where
   mMatch _   _ (_ ,CDEmpty)   = []
   mMatch env d (hs,m@CDMap{}) = go d (hs,m)
     where
-#if __GLASGOW_HASKELL__ >= 914
-      go (PrefixCon ps) = mapFor cdPrefixCon >=> mMatch env (dropInvisPats ps)
-#else
+#if __GLASGOW_HASKELL__ < 914
       -- TODO(xich): properly handle tyargs here!
       go (PrefixCon _tyargs ps) = mapFor cdPrefixCon >=> mMatch env ps
+#else
+      go (PrefixCon ps) = mapFor cdPrefixCon >=> mMatch env (dropInvisPats ps)
 #endif
       go (InfixCon p1 p2) = mapFor cdInfixCon >=> mMatch env p1 >=> mMatch env p2
       go _ = const [] -- TODO

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -177,8 +177,10 @@ instance PatternMap LMap where
       go (HsWordPrim _ i)   = m { lmWordPrim = mAlter env vs i f (lmWordPrim m) }
       go (HsInt64Prim _ i)  = m { lmInt64Prim = mAlter env vs i f (lmInt64Prim m) }
       go (HsWord64Prim _ i) = m { lmWord64Prim = mAlter env vs i f (lmWord64Prim m) }
+#if __GLASGOW_HASKELL__ < 914
       go HsInteger{} = missingSyntax "HsInteger"
       go HsRat{} = missingSyntax "HsRat"
+#endif
       go HsFloatPrim{} = missingSyntax "HsFloatPrim"
       go HsDoublePrim{} = missingSyntax "HsDoublePrim"
 #if __GLASGOW_HASKELL__ < 908
@@ -409,7 +411,11 @@ instance PatternMap EMap where
       go HsPragE{} = missingSyntax "HsPragE"
       go HsTypedBracket{} = missingSyntax "HsTypedBracket"
       go HsUntypedBracket{} = missingSyntax "HsUntypedBracket"
+#if __GLASGOW_HASKELL__ >= 914
+      go HsHole{} = missingSyntax "HsHole"
+#else
       go HsUnboundVar{} = missingSyntax "HsUnboundVar"
+#endif
       go HsOverLabel{} = missingSyntax "HsOverLabel"
       go HsAppType{} = missingSyntax "HsAppType"
       go ExplicitSum{} = missingSyntax "ExplicitSum"
@@ -674,7 +680,11 @@ emptyCDMapWrapper :: CDMap a
 emptyCDMapWrapper = CDMap mEmpty mEmpty
 
 instance PatternMap CDMap where
+#if __GLASGOW_HASKELL__ >= 914
+  type Key CDMap = HsConDetails (LocatedA (Pat GhcPs)) (HsRecFields GhcPs (LocatedA (Pat GhcPs)))
+#else
   type Key CDMap = HsConDetails (HsConPatTyArg GhcPs) (LocatedA (Pat GhcPs)) (HsRecFields GhcPs (LocatedA (Pat GhcPs)))
+#endif
 
   mEmpty :: CDMap a
   mEmpty = CDEmpty
@@ -691,8 +701,12 @@ instance PatternMap CDMap where
   mAlter env vs d f CDEmpty   = mAlter env vs d f emptyCDMapWrapper
   mAlter env vs d f m@CDMap{} = go d
     where
+#if __GLASGOW_HASKELL__ >= 914
+      go (PrefixCon ps) = m { cdPrefixCon = mAlter env vs ps f (cdPrefixCon m) }
+#else
       -- TODO(xich): properly handle tyargs here!
       go (PrefixCon _tyargs ps) = m { cdPrefixCon = mAlter env vs ps f (cdPrefixCon m) }
+#endif
       go (RecCon _) = missingSyntax "RecCon"
       go (InfixCon p1 p2) = m { cdInfixCon = mAlter env vs p1
                                               (toA (mAlter env vs p2 f))
@@ -702,8 +716,12 @@ instance PatternMap CDMap where
   mMatch _   _ (_ ,CDEmpty)   = []
   mMatch env d (hs,m@CDMap{}) = go d (hs,m)
     where
+#if __GLASGOW_HASKELL__ >= 914
+      go (PrefixCon ps) = mapFor cdPrefixCon >=> mMatch env ps
+#else
       -- TODO(xich): properly handle tyargs here!
       go (PrefixCon _tyargs ps) = mapFor cdPrefixCon >=> mMatch env ps
+#endif
       go (InfixCon p1 p2) = mapFor cdInfixCon >=> mMatch env p1 >=> mMatch env p2
       go _ = const [] -- TODO
 
@@ -823,11 +841,11 @@ instance PatternMap GRHSSMap where
         env' = foldr extendAlphaEnvInternal env bs
         vs' = vs `exceptQ` bs
     in GRHSSMap (mAlter env vs lbs
-                  (toA (mAlter env' vs' (map unLoc $ grhssGRHSs grhss) f)) m)
+                  (toA (mAlter env' vs' (map unLoc $ grhssList grhss) f)) m)
 
   mMatch :: MatchEnv -> Key GRHSSMap -> (Substitution, GRHSSMap a) -> [(Substitution, a)]
   mMatch env grhss = mapFor unGRHSSMap >=> mMatch env lbs
-                      >=> mMatch env' (map unLoc $ grhssGRHSs grhss)
+                      >=> mMatch env' (map unLoc $ grhssList grhss)
     where
       lbs = grhssLocalBinds  grhss
       bs = collectLocalBinders CollNoDictBinders lbs
@@ -1147,8 +1165,10 @@ instance PatternMap TyMap where
       go HsKindSig{} = missingSyntax "HsKindSig"
       go HsSpliceTy{} = missingSyntax "HsSpliceTy"
       go HsDocTy{} = missingSyntax "HsDocTy"
+#if __GLASGOW_HASKELL__ < 914
       go HsBangTy{} = missingSyntax "HsBangTy"
       go HsRecTy{} = missingSyntax "HsRecTy"
+#endif
       go (HsAppTy _ ty1 ty2) = m { tyHsAppTy = mAlter env vs ty1 (toA (mAlter env vs ty2 f)) (tyHsAppTy m) }
       go (HsForAllTy _ vis ty') | (isVisible, bndrs) <- splitVisBinders vis =
         m { tyHsForAllTy = mAlter env vs isVisible (toA (mAlter env vs (bndrs, ty') f)) (tyHsForAllTy m) }

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -702,7 +702,7 @@ instance PatternMap CDMap where
   mAlter env vs d f m@CDMap{} = go d
     where
 #if __GLASGOW_HASKELL__ >= 914
-      go (PrefixCon ps) = m { cdPrefixCon = mAlter env vs ps f (cdPrefixCon m) }
+      go (PrefixCon ps) = m { cdPrefixCon = mAlter env vs (dropInvisPats ps) f (cdPrefixCon m) }
 #else
       -- TODO(xich): properly handle tyargs here!
       go (PrefixCon _tyargs ps) = m { cdPrefixCon = mAlter env vs ps f (cdPrefixCon m) }
@@ -717,7 +717,7 @@ instance PatternMap CDMap where
   mMatch env d (hs,m@CDMap{}) = go d (hs,m)
     where
 #if __GLASGOW_HASKELL__ >= 914
-      go (PrefixCon ps) = mapFor cdPrefixCon >=> mMatch env ps
+      go (PrefixCon ps) = mapFor cdPrefixCon >=> mMatch env (dropInvisPats ps)
 #else
       -- TODO(xich): properly handle tyargs here!
       go (PrefixCon _tyargs ps) = mapFor cdPrefixCon >=> mMatch env ps

--- a/Retrie/Replace.hs
+++ b/Retrie/Replace.hs
@@ -86,7 +86,7 @@ replaceImpl c e = do
       res' <- (mkM (parenify c) `extM` parenifyT c `extM` parenifyP c) r0
       -- Make sure the replacement has the same anchor as the thing
       -- being replaced
-      let res = transferAnchor e res'
+      let res = transferEpAnn e res'
 
       -- prune the resulting expression and log it with location
       orig <- printNoLeadingSpaces <$> pruneA e

--- a/Retrie/Replace.hs
+++ b/Retrie/Replace.hs
@@ -83,14 +83,10 @@ replaceImpl c e = do
       -- copy appropriate annotations from old expression to template
       r0 <- addAllAnnsT e r
       -- add parens to template if needed
-      res' <- (mkM (parenify c) `extM` parenifyT c `extM` parenifyP c) r0
-      -- Make sure the replacement has the same anchor as the thing
-      -- being replaced
-      let res = transferEpAnn e res'
+      res <- (mkM (parenify c) `extM` parenifyT c `extM` parenifyP c) r0
 
       -- prune the resulting expression and log it with location
       orig <- printNoLeadingSpaces <$> pruneA e
-      -- orig <- printA' <$> pruneA e
 
       repl <- printNoLeadingSpaces <$> pruneA res
       -- repl <- printA' <$> pruneA r
@@ -109,7 +105,7 @@ replaceImpl c e = do
       let replacement = Replacement (getLocA e) orig repl
       TransformT $ lift $ tell $ Change [replacement] [tImports]
       -- make the actual replacement
-      return res'
+      return res
 
 
 -- | Records a replacement made. In cases where we cannot use ghc-exactprint

--- a/Retrie/Rewrites/Function.hs
+++ b/Retrie/Rewrites/Function.hs
@@ -71,13 +71,6 @@ matchToRewrites e imps dir (L _ alt) = do
   qs <- backtickRules e imps dir grhss pats
   return $ qs ++ concat qss
 
-getMatchPats :: Match GhcPs (LHsExpr GhcPs) -> [LPat GhcPs]
-#if __GLASGOW_HASKELL__ < 912
-getMatchPats = m_pats
-#else
-getMatchPats = unLoc . m_pats
-#endif
-
 type AppBuilder =
   LHsExpr GhcPs -> [LHsExpr GhcPs] -> TransformT IO (LHsExpr GhcPs)
 

--- a/Retrie/Rewrites/Function.hs
+++ b/Retrie/Rewrites/Function.hs
@@ -102,13 +102,14 @@ makeFunctionQuery e imps dir grhss mkAppFn (argpats, bndpats)
   | any (not . irrefutablePat) bndpats = return []
   | otherwise = do
     let
-      GRHSs _ rhss lbs = grhss
+      GRHSs _ _ lbs = grhss
+      rhssList = grhssList grhss
       bs = collectPatsBinders CollNoDictBinders argpats
     -- See Note [Wildcards]
     (es,(_,bs')) <- runStateT (mapM patToExpr argpats) (wildSupply bs, bs)
     -- lift $ debugPrint Loud "makeFunctionQuery:e="  [showAst e]
     lhs <- mkAppFn e es
-    for rhss $ \ grhs -> do
+    for rhssList $ \ grhs -> do
       le <- mkLet lbs (grhsToExpr grhs)
       rhs <- mkLams bndpats le
       let

--- a/Retrie/Rewrites/Patterns.hs
+++ b/Retrie/Rewrites/Patterns.hs
@@ -53,10 +53,10 @@ mkPatRewrite
   :: Direction
   -> AnnotatedImports
   -> LocatedN RdrName
-#if __GLASGOW_HASKELL__ >= 914
-  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
-#else
+#if __GLASGOW_HASKELL__ < 914
   -> HsConDetails Void (LocatedN RdrName) [RecordPatSynField GhcPs]
+#else
+  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
 #endif
   -> LPat GhcPs
   -> TransformT IO (Rewrite (LPat GhcPs))
@@ -83,17 +83,7 @@ mkPatRewrite dir imports patName params rhs = do
       = (L l (ConPat x (setEntryDP nm dp) args))
     setEntryDPTunderConPatIn p _ = p
 
-#if __GLASGOW_HASKELL__ >= 914
-asPat
-  :: Monad m
-  => LocatedN RdrName
-  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
-  -> TransformT m (LPat GhcPs)
-asPat patName params = do
-  params' <- bitraverseHsConDetails mkVarPat convertFields params
-  mkConPatIn patName params'
-  where
-#else
+#if __GLASGOW_HASKELL__ < 914
 asPat
   :: Monad m
   => LocatedN RdrName
@@ -106,6 +96,16 @@ asPat patName params = do
 
     convertTyVars :: (Monad m) => [Void] -> TransformT m [HsConPatTyArg GhcPs]
     convertTyVars _ = return []
+#else
+asPat
+  :: Monad m
+  => LocatedN RdrName
+  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
+  -> TransformT m (LPat GhcPs)
+asPat patName params = do
+  params' <- bitraverseHsConDetails mkVarPat convertFields params
+  mkConPatIn patName params'
+  where
 #endif
 
     convertFields :: (Monad m) => [RecordPatSynField GhcPs]
@@ -138,10 +138,10 @@ mkExpRewrite
   :: Direction
   -> AnnotatedImports
   -> LocatedN RdrName
-#if __GLASGOW_HASKELL__ >= 914
-  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
-#else
+#if __GLASGOW_HASKELL__ < 914
   -> HsConDetails Void (LocatedN RdrName) [RecordPatSynField GhcPs]
+#else
+  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
 #endif
   -> LPat GhcPs
   -> HsPatSynDir GhcPs
@@ -150,10 +150,10 @@ mkExpRewrite dir imports patName params rhs patDir = do
   fe <- mkLocatedHsVar patName
   -- lift $ debugPrint Loud "mkExpRewrite:fe="  [showAst fe]
   let altsFromParams = case params of
-#if __GLASGOW_HASKELL__ >= 914
-        PrefixCon names -> buildMatch names rhs
-#else
+#if __GLASGOW_HASKELL__ < 914
         PrefixCon _tyargs names -> buildMatch names rhs
+#else
+        PrefixCon names -> buildMatch names rhs
 #endif
         InfixCon a1 a2 -> buildMatch [a1, a2] rhs
         RecCon{} -> missingSyntax "RecCon"

--- a/Retrie/Rewrites/Patterns.hs
+++ b/Retrie/Rewrites/Patterns.hs
@@ -14,7 +14,9 @@ import Control.Monad.State (StateT(runStateT))
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Maybe
+#if __GLASGOW_HASKELL__ < 914
 import Data.Void
+#endif
 
 import Retrie.ExactPrint
 import Retrie.Expr
@@ -51,7 +53,11 @@ mkPatRewrite
   :: Direction
   -> AnnotatedImports
   -> LocatedN RdrName
+#if __GLASGOW_HASKELL__ >= 914
+  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
+#else
   -> HsConDetails Void (LocatedN RdrName) [RecordPatSynField GhcPs]
+#endif
   -> LPat GhcPs
   -> TransformT IO (Rewrite (LPat GhcPs))
 mkPatRewrite dir imports patName params rhs = do
@@ -77,6 +83,17 @@ mkPatRewrite dir imports patName params rhs = do
       = (L l (ConPat x (setEntryDP nm dp) args))
     setEntryDPTunderConPatIn p _ = p
 
+#if __GLASGOW_HASKELL__ >= 914
+asPat
+  :: Monad m
+  => LocatedN RdrName
+  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
+  -> TransformT m (LPat GhcPs)
+asPat patName params = do
+  params' <- bitraverseHsConDetails mkVarPat convertFields params
+  mkConPatIn patName params'
+  where
+#else
 asPat
   :: Monad m
   => LocatedN RdrName
@@ -89,6 +106,7 @@ asPat patName params = do
 
     convertTyVars :: (Monad m) => [Void] -> TransformT m [HsConPatTyArg GhcPs]
     convertTyVars _ = return []
+#endif
 
     convertFields :: (Monad m) => [RecordPatSynField GhcPs]
                       -> TransformT m (HsRecFields GhcPs (LPat GhcPs))
@@ -120,7 +138,11 @@ mkExpRewrite
   :: Direction
   -> AnnotatedImports
   -> LocatedN RdrName
+#if __GLASGOW_HASKELL__ >= 914
+  -> HsConDetails (LocatedN RdrName) [RecordPatSynField GhcPs]
+#else
   -> HsConDetails Void (LocatedN RdrName) [RecordPatSynField GhcPs]
+#endif
   -> LPat GhcPs
   -> HsPatSynDir GhcPs
   -> TransformT IO [Rewrite (LHsExpr GhcPs)]
@@ -128,7 +150,11 @@ mkExpRewrite dir imports patName params rhs patDir = do
   fe <- mkLocatedHsVar patName
   -- lift $ debugPrint Loud "mkExpRewrite:fe="  [showAst fe]
   let altsFromParams = case params of
+#if __GLASGOW_HASKELL__ >= 914
+        PrefixCon names -> buildMatch names rhs
+#else
         PrefixCon _tyargs names -> buildMatch names rhs
+#endif
         InfixCon a1 a2 -> buildMatch [a1, a2] rhs
         RecCon{} -> missingSyntax "RecCon"
   alts <- case patDir of

--- a/hse/Fixity.hs
+++ b/hse/Fixity.hs
@@ -34,8 +34,10 @@ hseToGHC :: HSE.Fixity -> (FastString, (FastString, Fixity))
 hseToGHC (HSE.Fixity assoc p nm) =
 #if __GLASGOW_HASKELL__ < 908
   (fs, (fs, Fixity (SourceText nm') p (dir assoc)))
-#else
+#elif __GLASGOW_HASKELL__ < 912
   (fs, (fs, Fixity (SourceText (fsLit nm')) p (dir assoc)))
+#else
+  (fs, (fs, Fixity p (dir assoc)))
 #endif
 
   where

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -13,7 +13,7 @@ license: MIT
 license-file: LICENSE
 author: Andrew Farmer <andrew@andrewfarmer.name>
 maintainer: Andrew Farmer <andrew@andrewfarmer.name>
-copyright: 
+copyright:
   Copyright (c) 2025 Andrew Farmer
   Copyright (c) 2020-2024 Facebook, Inc. and its affiliates.
 category: Development
@@ -26,7 +26,7 @@ extra-source-files:
   README.md
   tests/inputs/*.custom
   tests/inputs/*.test
-tested-with: GHC ==9.6.7, GHC ==9.8.4
+tested-with: GHC ==9.6.7, GHC ==9.8.4, GHC ==9.12.2
 
 description:
   Retrie is a tool for codemodding Haskell. Key goals include:
@@ -78,16 +78,16 @@ library
     Retrie.Util
   GHC-Options: -Wall -Werror
   build-depends:
-    ansi-terminal >= 0.10.3 && < 1.1,
+    ansi-terminal >= 0.10.3 && < 1.2,
     async >= 2.2.2 && < 2.3,
-    base >= 4.11 && < 4.20,
+    base >= 4.11 && < 4.22,
     bytestring >= 0.10.8 && < 0.13,
     containers >= 0.5.11 && < 0.8,
-    data-default >= 0.7.1 && < 0.8,
+    data-default >= 0.7.1 && < 0.9,
     directory >= 1.3.1 && < 1.4,
     filepath >= 1.4.2 && < 1.6,
-    ghc >= 9.6 && < 9.9,
-    ghc-exactprint >= 1.5.0 && < 1.9,
+    ghc >= 9.6 && < 9.9 || >= 9.12 && < 9.13,
+    ghc-exactprint >= 1.7.1 && < 1.13,
     list-t >= 1.0.4 && < 1.1,
     mtl >= 2.2.2 && < 2.4,
     optparse-applicative >= 0.15.1 && < 0.19,
@@ -115,7 +115,7 @@ executable retrie
   GHC-Options: -Wall -Werror
   build-depends:
     retrie,
-    base >= 4.11 && < 4.20,
+    base >= 4.11 && < 4.22,
     haskell-src-exts >= 1.23.0 && < 1.24,
     ghc-paths
   default-language: Haskell2010
@@ -132,7 +132,7 @@ executable demo-retrie
   GHC-Options: -Wall -Werror
   build-depends:
     retrie,
-    base >= 4.11 && < 4.20,
+    base >= 4.11 && < 4.22,
     haskell-src-exts >= 1.23.0 && < 1.24,
     ghc-paths
   default-language: Haskell2010

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -21,7 +21,6 @@ build-type: Simple
 cabal-version: >=1.10
 extra-source-files:
   CHANGELOG.md
-  CODE_OF_CONDUCT.md
   CONTRIBUTING.md
   README.md
   tests/inputs/*.custom

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -26,7 +26,7 @@ extra-source-files:
   README.md
   tests/inputs/*.custom
   tests/inputs/*.test
-tested-with: GHC ==9.6.7, GHC ==9.8.4, GHC ==9.12.2
+tested-with: GHC ==9.6.7, GHC ==9.8.4, GHC ==9.12.2, GHC ==9.14.1
 
 description:
   Retrie is a tool for codemodding Haskell. Key goals include:
@@ -77,17 +77,19 @@ library
     Retrie.Universe,
     Retrie.Util
   GHC-Options: -Wall -Werror
+  if impl(ghc >= 9.10)
+    GHC-Options: -Wno-incomplete-record-selectors
   build-depends:
     ansi-terminal >= 0.10.3 && < 1.2,
     async >= 2.2.2 && < 2.3,
-    base >= 4.11 && < 4.22,
+    base >= 4.11 && < 4.23,
     bytestring >= 0.10.8 && < 0.13,
-    containers >= 0.5.11 && < 0.8,
+    containers >= 0.5.11 && < 0.9,
     data-default >= 0.7.1 && < 0.9,
     directory >= 1.3.1 && < 1.4,
     filepath >= 1.4.2 && < 1.6,
-    ghc >= 9.6 && < 9.9 || >= 9.12 && < 9.13,
-    ghc-exactprint >= 1.7.1 && < 1.13,
+    ghc >= 9.6 && < 9.9 || >= 9.12 && < 9.13 || >= 9.14 && < 9.15,
+    ghc-exactprint >= 1.7.1 && < 1.15,
     list-t >= 1.0.4 && < 1.1,
     mtl >= 2.2.2 && < 2.4,
     optparse-applicative >= 0.15.1 && < 0.19,
@@ -115,7 +117,7 @@ executable retrie
   GHC-Options: -Wall -Werror
   build-depends:
     retrie,
-    base >= 4.11 && < 4.22,
+    base >= 4.11 && < 4.23,
     haskell-src-exts >= 1.23.0 && < 1.24,
     ghc-paths
   default-language: Haskell2010
@@ -132,7 +134,7 @@ executable demo-retrie
   GHC-Options: -Wall -Werror
   build-depends:
     retrie,
-    base >= 4.11 && < 4.22,
+    base >= 4.11 && < 4.23,
     haskell-src-exts >= 1.23.0 && < 1.24,
     ghc-paths
   default-language: Haskell2010

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -25,7 +25,7 @@ extra-source-files:
   README.md
   tests/inputs/*.custom
   tests/inputs/*.test
-tested-with: GHC ==9.6.7, GHC ==9.8.4, GHC ==9.12.2, GHC ==9.14.1
+tested-with: GHC ==9.6.7, GHC ==9.8.4, GHC ==9.12.2, GHC ==9.12.4, GHC ==9.14.1
 
 description:
   Retrie is a tool for codemodding Haskell. Key goals include:

--- a/tests/AllTests.hs
+++ b/tests/AllTests.hs
@@ -45,6 +45,12 @@ allTests libdir rtVerbosity = do
       [ TestLabel rtName $ TestCase $ runTest libdir p RetrieTest{..}
       | testFile <- testFiles
       , takeExtension testFile == ".test"
+#if __GLASGOW_HASKELL__ < 908
+      -- The TypeAbstractions pragma is unknown to the GHC 9.6 parser, so
+      -- retrie cannot parse this test's target module there. The pre-9.14
+      -- code path it exercises is still covered by the 9.8/9.12 runs.
+      , testFile /= "TypeAbs.test"
+#endif
       , let
           rtName = dropExtension testFile
           rtTest = testFile

--- a/tests/inputs/TypeAbs.test
+++ b/tests/inputs/TypeAbs.test
@@ -1,0 +1,23 @@
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Regression test for type applications in constructor patterns. On
+# GHC >= 9.14 the type argument is an InvisPat element of the PrefixCon
+# pattern list (older GHCs kept it in a separate tyargs field that retrie
+# ignored). Unfolding baz runs patToExpr over its argument pattern
+# (Just @Int x), which must ignore the type argument rather than crash
+# with 'patToExpr InvisPat'.
+-u TypeAbs.baz
+===
+ {-# LANGUAGE TypeApplications #-}
+ {-# LANGUAGE TypeAbstractions #-}
+ 
+ module TypeAbs where
+ 
+ baz :: Maybe Int -> Int
+ baz (Just @Int x) = x
+ baz Nothing = 0
+ 
+ f :: Int
+-f = baz (Just 1)
++f = 1


### PR DESCRIPTION
This PR builds on top of #9, adding support for GHC 9.14.1. All tests remain green on all supported versions of GHC. One new test pins the existing behaviour relating to TypeAbstractions.